### PR TITLE
fix: refetch history when on production toggle

### DIFF
--- a/pages/state/[stateCode]/history/[date].js
+++ b/pages/state/[stateCode]/history/[date].js
@@ -51,7 +51,7 @@ export default () => {
       .catch((e) => {
         console.log(e)
       })
-  }, [stateCode])
+  }, [stateCode, production])
 
   return (
     <Layout


### PR DESCRIPTION
A simple PR to fetch the correct history when toggling between production/staging. This makes the history page match the state pages.