### PR TITLE
fix: use correct links for state/date history

### DIFF
--- a/pages/state/[stateCode]/history/[date].js
+++ b/pages/state/[stateCode]/history/[date].js
@@ -104,10 +104,10 @@ export default () => {
       dataIndex: 'batch__link',
       key: 'batch__link',
       width: 90,
-      render: (note) =>
-        note ? (
+      render: (link) =>
+        link ? (
           <a
-            href="https://github.com/COVID19Tracking/issues/issues/813"
+            href={link}
             target="_blank"
           >
             Link


### PR DESCRIPTION
I think a placeholder got left behind here. 

Please make sure I haven't committed some grievous React sin and somehow broken escaping because I don't really know what I'm doing, but it seemed to work in local testing.